### PR TITLE
Update package to use Darksky.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 [![License](https://poser.pugx.org/vertigolabs/overcast/license.svg)](https://packagist.org/packages/vertigolabs/overcast)
 [![Total Downloads](https://poser.pugx.org/vertigolabs/overcast/downloads.svg)](https://packagist.org/packages/vertigolabs/overcast)
 
-An easy to use wrapper for the [Forecast.io](https://forecast.io) API v2.
+An easy to use wrapper for the [Dark Sky](https://darksky.net/) API (formerly [Forecast.io](https://forecast.io)).
 
-Overcast will query the Forecast.io API for weather information for the longitude and latitude you specify. Additionally
 you may specify the specific time, past or present. 
+Overcast will query the Dark Sky API for weather information for the longitude and latitude you specify. Additionally
 
-See the [Forecast.io API documentation](https://developer.forecast.io/docs/v2) for more information.
+See the [Dark Sky API documentation](https://darksky.net/dev/docs) for more information.
 
 ## Installation
 Installation is as simple as using [Composer](http://getcomposer.org/):
@@ -26,7 +26,7 @@ Installation is as simple as using [Composer](http://getcomposer.org/):
 ```
 
 ## Client Adapters
-Overcast uses client adapters to connect to the Forecast.io API. This gives you the ability to create your own adapter for whatever HTTP client you'd like to use. This is especially useful for people who have special needs when dealing with retrieving data from third parties (firewalls, proxies, etc)
+Overcast uses client adapters to connect to the Dark Sky API. This gives you the ability to create your own adapter for whatever HTTP client you'd like to use. This is especially useful for people who have special needs when dealing with retrieving data from third parties (firewalls, proxies, etc)
 
 Overcast comes with two client adapters ready for use, FileGetContentsClientAdapter and GuzzleClientAdapter. You can also create your own by simply implementing the ClientAdapterInterface
  
@@ -41,10 +41,10 @@ $overcast = new \VertigoLabs\Overcast\Overcast('YOUR API KEY', new MyAwesomeClie
 ```
 
 ## Example
-Since the Forecast.io API is simple, Overcast is equally easy to use.
+Since the Dark Sky API is simple, Overcast is equally easy to use.
 Simply create an instance of the Overcast class, then call the getForecast() method.
 
-Overcast::getForecast() returns a nicely structured Forecast object which contains other data structures for handy access to all of the response data from Forecast.io.  
+Overcast::getForecast() returns a nicely structured Forecast object which contains other data structures for handy access to all of the response data from Dark Sky.
 
 ```php
 $overcast = new \VertigoLabs\Overcast\Overcast('YOUR API KEY');

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 An easy to use wrapper for the [Dark Sky](https://darksky.net/) API (formerly [Forecast.io](https://forecast.io)).
 
-you may specify the specific time, past or present. 
 Overcast will query the Dark Sky API for weather information for the longitude and latitude you specify. Additionally
+you may specify the specific time, past or present.
 
 See the [Dark Sky API documentation](https://darksky.net/dev/docs) for more information.
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "vertigolabs/overcast",
-    "description": "An easy to use wrapper for the Forecast.io API",
+    "description": "An easy to use wrapper for the Dark Sky API (formerly Forecast.io)",
     "license": "MIT",
     "authors": [
         {
@@ -9,7 +9,7 @@
         }
     ],
     "suggest": {
-        "guzzlehttp/guzzle": "Allows for better handling of http connections to Forecast.io webservice"
+        "guzzlehttp/guzzle": "Allows for better handling of http connections to Dark Sky webservice"
     },
 	"autoload": {
 	  "psr-4": {

--- a/src/ClientAdapters/GuzzleClientAdapter.php
+++ b/src/ClientAdapters/GuzzleClientAdapter.php
@@ -15,9 +15,9 @@ use VertigoLabs\Overcast\Overcast;
  * Class GuzzleClientAdapter
  *
  * The Guzzle client adapter uses Guzzle to connect to
+ * the Dark Sky API
  *
  * @package VertigoLabs\Overcast\ClientAdapters
- * the Dark Sky API
  */
 class GuzzleClientAdapter implements ClientAdapterInterface
 {
@@ -40,8 +40,8 @@ class GuzzleClientAdapter implements ClientAdapterInterface
     }
 
     /**
-     * form of an array
      * Returns the response data from the Dark Sky in the
+     * form of an array.
      *
      * @param float $latitude
      * @param float $longitude

--- a/src/ClientAdapters/GuzzleClientAdapter.php
+++ b/src/ClientAdapters/GuzzleClientAdapter.php
@@ -15,9 +15,9 @@ use VertigoLabs\Overcast\Overcast;
  * Class GuzzleClientAdapter
  *
  * The Guzzle client adapter uses Guzzle to connect to
- * the Forecast.io api
  *
  * @package VertigoLabs\Overcast\ClientAdapters
+ * the Dark Sky API
  */
 class GuzzleClientAdapter implements ClientAdapterInterface
 {
@@ -40,8 +40,8 @@ class GuzzleClientAdapter implements ClientAdapterInterface
     }
 
     /**
-     * Returns the response data from the Forecast.io in the
      * form of an array
+     * Returns the response data from the Dark Sky in the
      *
      * @param float $latitude
      * @param float $longitude
@@ -76,7 +76,7 @@ class GuzzleClientAdapter implements ClientAdapterInterface
     }
 
     /**
-     * Returns the relevant response headers from the Forecast.io API
+     * Returns the relevant response headers from the Dark Sky API.
      *
      * @return array
      */

--- a/src/Forecast.php
+++ b/src/Forecast.php
@@ -15,9 +15,9 @@ use VertigoLabs\Overcast\ValueObjects\DataPoint;
  * Class Forecast
  *
  * The Forecast class represents the data returned
- * from the Forecast.io API
  *
  * @package VertigoLabs\Overcast
+ * from the Dark Sky API
  */
 class Forecast
 {

--- a/src/Forecast.php
+++ b/src/Forecast.php
@@ -15,9 +15,9 @@ use VertigoLabs\Overcast\ValueObjects\DataPoint;
  * Class Forecast
  *
  * The Forecast class represents the data returned
+ * from the Dark Sky API
  *
  * @package VertigoLabs\Overcast
- * from the Dark Sky API
  */
 class Forecast
 {

--- a/src/Overcast.php
+++ b/src/Overcast.php
@@ -19,9 +19,9 @@ use VertigoLabs\Overcast\ClientAdapters\GuzzleClientAdapter;
 /**
  * Class Overcast
  *
- * The Overcast class provides access to the Forecast.io API
  *
  * @package VertigoLabs\Overcast
+ * The Overcast class provides access to the Dark Sky API
  */
 class Overcast
 {
@@ -38,7 +38,7 @@ class Overcast
      */
     private $apiCalls = 0;
     /**
-     * The adapter used to connect to the Forecast.io webservice
+     * The adapter used to connect to the Dark Sky webservice.
      * @var ClientAdapterInterface
      */
     private $adapter;
@@ -47,7 +47,7 @@ class Overcast
      * Construct the Overcast class.
      *
      * You may optionally specify an adapter class which is used
-     * to connect to the Forecast.io API. If no adapter is specified
+     * to connect to the Dark Sky API. If no adapter is specified
      * a default will be chosen. If the Guzzle client is available the
      * GuzzleAdapter will be chosen, otherwise the FileGetContentsAdapter
      * will be used.

--- a/src/Overcast.php
+++ b/src/Overcast.php
@@ -19,9 +19,9 @@ use VertigoLabs\Overcast\ClientAdapters\GuzzleClientAdapter;
 /**
  * Class Overcast
  *
+ * The Overcast class provides access to the Dark Sky API
  *
  * @package VertigoLabs\Overcast
- * The Overcast class provides access to the Dark Sky API
  */
 class Overcast
 {

--- a/src/Overcast.php
+++ b/src/Overcast.php
@@ -25,7 +25,7 @@ use VertigoLabs\Overcast\ClientAdapters\GuzzleClientAdapter;
  */
 class Overcast
 {
-    const API_ENDPOINT = 'https://api.forecast.io/forecast/';
+    const API_ENDPOINT = 'https://api.darksky.net/forecast/';
 
     /**
      * Private API Key


### PR DESCRIPTION
It was announced on September 20th, 2016 that forecast.io would now be replaced by darksky.net (http://blog.darksky.net/introducing-darksky-net/). The API appears to be identical, but just hosting at a new endpoint.

For the time being requests to apiforecast.io are being updated to api.darksky.net, however this will only be done through the end of the year.

As such I have updated the API endpoint and all references to Forecast.io have been updated to Darksky.net.
