### PR TITLE
Add requirements: php 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Installation is as simple as using [Composer](http://getcomposer.org/):
     }
 }
 ```
+Note: PHP 5.4 or greater is required
 
 ## Client Adapters
 Overcast uses client adapters to connect to the Dark Sky API. This gives you the ability to create your own adapter for whatever HTTP client you'd like to use. This is especially useful for people who have special needs when dealing with retrieving data from third parties (firewalls, proxies, etc)


### PR DESCRIPTION
I'm running 5.3.3 and throws multiple errors related to 5.4 minimum requirements.  Eg:
http://stackoverflow.com/questions/13388541/php-parse-error-syntax-error-unexpected-t-object-operator
http://stackoverflow.com/questions/16358973/parse-error-syntax-error-unexpected-with-php-5-3

Wish you supported 5.3.3 :(